### PR TITLE
feat: add auth and supporter plan

### DIFF
--- a/apps/web/app/(account)/dashboard/page.tsx
+++ b/apps/web/app/(account)/dashboard/page.tsx
@@ -1,0 +1,14 @@
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+
+export default async function DashboardPage() {
+  const session = await auth();
+  if (!session) redirect("/api/auth/signin");
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-10 space-y-4">
+      <h1 className="text-3xl font-bold">Dashboard</h1>
+      <p className="text-text-primary">Plan: {session.user.plan}</p>
+      <p className="text-text-secondary">Usage: {session.user.usage}</p>
+    </div>
+  );
+}

--- a/apps/web/app/(site)/support/page.tsx
+++ b/apps/web/app/(site)/support/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+export default function SupportPage() {
+  const checkout = async () => {
+    const res = await fetch("/api/stripe/checkout", { method: "POST" });
+    const data = await res.json();
+    if (data.url) window.location.href = data.url;
+  };
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-10 space-y-8">
+      <h1 className="text-3xl font-bold">Support</h1>
+      <div className="grid gap-6 md:grid-cols-3">
+        <div className="rounded-lg border border-border bg-surface p-6 text-center">
+          <h2 className="mb-4 text-xl font-semibold">FREE</h2>
+          <p className="mb-6 text-sm text-text-secondary">No sign-up needed</p>
+          <Button disabled>Current</Button>
+        </div>
+        <div className="rounded-lg border border-border bg-surface p-6 text-center">
+          <h2 className="mb-4 text-xl font-semibold">Supporter</h2>
+          <p className="mb-2 text-sm text-text-secondary">Ad-free, no captcha, faster</p>
+          <Button onClick={checkout}>Upgrade</Button>
+        </div>
+        <div className="rounded-lg border border-border bg-surface p-6 text-center opacity-50">
+          <h2 className="mb-4 text-xl font-semibold">Content Machine</h2>
+          <p className="text-sm text-text-secondary">Coming soon</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(site)/tools/page.tsx
+++ b/apps/web/app/(site)/tools/page.tsx
@@ -38,7 +38,13 @@ export default function ToolsPage() {
       <CategoryTabs categories={categoryData} active={active} onChange={setActive} />
       <div className="grid grid-cols-2 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
         {filtered.map((tool) => (
-          <ToolCard key={tool.id} icon={tool.icon} title={tool.title} description={tool.description} />
+          <ToolCard
+            key={tool.id}
+            icon={tool.icon}
+            title={tool.title}
+            description={tool.description}
+            premium={tool.premium}
+          />
         ))}
       </div>
     </div>

--- a/apps/web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export { GET, POST } from "@/lib/auth";

--- a/apps/web/app/api/stripe/checkout/route.ts
+++ b/apps/web/app/api/stripe/checkout/route.ts
@@ -1,0 +1,19 @@
+import { auth } from "@/lib/auth";
+import { stripe } from "@/lib/stripe";
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const session = await auth();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const checkout = await stripe.checkout.sessions.create({
+    mode: "subscription",
+    line_items: [{ price: process.env.STRIPE_SUPPORTER_PRICE_ID || "", quantity: 1 }],
+    success_url: `${process.env.NEXT_PUBLIC_APP_URL}/(account)/dashboard`,
+    cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/(site)/support`,
+    customer_email: session.user.email || undefined,
+    metadata: { userId: session.user.id },
+  });
+
+  return NextResponse.json({ url: checkout.url });
+}

--- a/apps/web/app/api/stripe/portal/route.ts
+++ b/apps/web/app/api/stripe/portal/route.ts
@@ -1,0 +1,19 @@
+import { auth } from "@/lib/auth";
+import { stripe } from "@/lib/stripe";
+import { users } from "@/lib/db";
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const session = await auth();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const record = users.get(session.user.id);
+  if (!record || !record.stripeCustomerId)
+    return NextResponse.json({ error: "No customer" }, { status: 400 });
+
+  const portal = await stripe.billingPortal.sessions.create({
+    customer: record.stripeCustomerId,
+    return_url: `${process.env.NEXT_PUBLIC_APP_URL}/(account)/dashboard`,
+  });
+
+  return NextResponse.json({ url: portal.url });
+}

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,37 @@
+import { stripe } from "@/lib/stripe";
+import { users } from "@/lib/db";
+import type Stripe from "stripe";
+
+export async function POST(req: Request) {
+  const body = await req.text();
+  const signature = req.headers.get("stripe-signature") || "";
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(body, signature, process.env.STRIPE_WEBHOOK_SECRET || "");
+  } catch (err) {
+    return new Response(`Webhook Error: ${(err as Error).message}`, { status: 400 });
+  }
+
+  if (event.type === "checkout.session.completed") {
+    const session = event.data.object as Stripe.Checkout.Session;
+    const userId = session.metadata?.userId;
+    if (userId) {
+      users.set(userId, {
+        plan: "SUPPORTER",
+        usage: 0,
+        stripeCustomerId: session.customer as string,
+        subscriptionStatus: "active",
+      });
+    }
+  } else if (event.type === "customer.subscription.updated") {
+    const sub = event.data.object as Stripe.Subscription;
+    for (const [id, record] of users.entries()) {
+      if (record.stripeCustomerId === sub.customer) {
+        record.subscriptionStatus = sub.status;
+        record.plan = sub.status === "active" ? "SUPPORTER" : "FREE";
+      }
+    }
+  }
+
+  return new Response(null, { status: 200 });
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,10 +1,17 @@
 import type { ReactNode } from "react";
 import "./globals.css";
+import { auth } from "@/lib/auth";
+import { Providers } from "./providers";
+import { UpgradeStrip } from "@/components/UpgradeStrip";
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default async function RootLayout({ children }: { children: ReactNode }) {
+  const session = await auth();
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {session?.user.plan === "FREE" && <UpgradeStrip />}
+        <Providers session={session}>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+import type { ReactNode } from "react";
+import type { Session } from "next-auth";
+
+export function Providers({ children, session }: { children: ReactNode; session: Session | null }) {
+  return <SessionProvider session={session}>{children}</SessionProvider>;
+}

--- a/apps/web/components/PremiumBadge.tsx
+++ b/apps/web/components/PremiumBadge.tsx
@@ -1,0 +1,7 @@
+export function PremiumBadge() {
+  return (
+    <span className="ml-2 rounded bg-primary px-1.5 py-0.5 text-xs font-medium text-white">
+      PRO
+    </span>
+  );
+}

--- a/apps/web/components/ToolCard.tsx
+++ b/apps/web/components/ToolCard.tsx
@@ -1,15 +1,20 @@
 import { type LucideIcon } from "lucide-react";
+import { PremiumBadge } from "./PremiumBadge";
 
 interface ToolCardProps {
   icon: LucideIcon;
   title: string;
   description: string;
+  premium?: boolean;
 }
 
-export function ToolCard({ icon: Icon, title, description }: ToolCardProps) {
+export function ToolCard({ icon: Icon, title, description, premium }: ToolCardProps) {
   return (
     <div className="rounded-lg border border-border bg-surface p-4 shadow-sm transition-shadow hover:shadow-md">
-      <Icon className="mb-2 h-6 w-6" />
+      <div className="mb-2 flex items-center">
+        <Icon className="h-6 w-6" />
+        {premium && <PremiumBadge />}
+      </div>
       <h3 className="font-semibold text-text-primary">{title}</h3>
       <p className="text-sm text-text-secondary">{description}</p>
     </div>

--- a/apps/web/constants/tools.ts
+++ b/apps/web/constants/tools.ts
@@ -9,6 +9,7 @@ export interface Tool {
   description: string;
   icon: LucideIcon;
   category: CategoryName;
+  premium?: boolean;
 }
 
 export const tools: Tool[] = [
@@ -38,14 +39,16 @@ export const tools: Tool[] = [
     title: "Video Convert",
     description: "Convert videos",
     icon: Video,
-    category: "Video"
+    category: "Video",
+    premium: true
   },
   {
     id: "ai-summarize",
     title: "AI Summarize",
     description: "Summarize text",
     icon: PenLine,
-    category: "AI Write"
+    category: "AI Write",
+    premium: true
   },
   {
     id: "file-unzip",

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -1,0 +1,33 @@
+import NextAuth from "next-auth";
+import Google from "next-auth/providers/google";
+import Email from "next-auth/providers/email";
+import { users } from "./db";
+
+export const { handlers: { GET, POST }, auth, signIn, signOut } = NextAuth({
+  providers: [
+    Google({
+      clientId: process.env.GOOGLE_CLIENT_ID || "",
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
+    }),
+    Email({
+      sendVerificationRequest({ identifier, url }) {
+        console.log("Login link", identifier, url);
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) token.sub = user.id || user.email;
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user && token.sub) {
+        const record = users.get(token.sub) || { plan: "FREE", usage: 0 };
+        session.user.id = token.sub;
+        session.user.plan = record.plan;
+        session.user.usage = record.usage;
+      }
+      return session;
+    },
+  },
+});

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -1,0 +1,11 @@
+export type Plan = "FREE" | "SUPPORTER";
+
+export interface UserRecord {
+  plan: Plan;
+  usage: number;
+  stripeCustomerId?: string;
+  subscriptionStatus?: string;
+}
+
+// simple in-memory store for demo purposes
+export const users = new Map<string, UserRecord>();

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -1,0 +1,5 @@
+import Stripe from "stripe";
+
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
+  apiVersion: "2024-04-10",
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,9 @@
     "lucide-react": "^0.292.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
-    "tailwind-merge": "^2.0.0"
+    "tailwind-merge": "^2.0.0",
+    "next-auth": "^4.24.5",
+    "stripe": "^12.17.0"
   },
   "devDependencies": {
     "typescript": "5.3.3",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -13,7 +13,11 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [{ "name": "next" }]
+    "plugins": [{ "name": "next" }],
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/apps/web/types/next-auth.d.ts
+++ b/apps/web/types/next-auth.d.ts
@@ -1,0 +1,12 @@
+import type { DefaultSession } from "next-auth";
+import { Plan } from "@/lib/db";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+      plan: Plan;
+      usage: number;
+    } & DefaultSession["user"];
+  }
+}


### PR DESCRIPTION
## Summary
- integrate NextAuth with Google OAuth and email
- add supporter plan with Stripe checkout, billing portal, and subscription webhook
- show plan status/usage and premium indicators in UI

## Testing
- `pnpm install` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm build` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b4db0a61bc83338cbc1eba6dc463e1