### PR TITLE
feat: add multipart upload and file retention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+dist
+.env

--- a/apps/web/app/api/download/[id]/route.ts
+++ b/apps/web/app/api/download/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { s3, BUCKET } from "@/lib/s3";
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const file = await prisma.file.findUnique({ where: { id: params.id } });
+  if (!file) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const command = new GetObjectCommand({ Bucket: BUCKET, Key: file.key });
+  const url = await getSignedUrl(s3, command, { expiresIn: 60 });
+  return NextResponse.json({ url, name: file.name });
+}

--- a/apps/web/app/api/upload/complete/route.ts
+++ b/apps/web/app/api/upload/complete/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { s3, BUCKET } from "@/lib/s3";
+import { CompleteMultipartUploadCommand } from "@aws-sdk/client-s3";
+
+export async function POST(req: Request) {
+  const { fileId, uploadId, parts } = await req.json();
+  const file = await prisma.file.findUnique({ where: { id: fileId } });
+  if (!file) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  await s3.send(
+    new CompleteMultipartUploadCommand({
+      Bucket: BUCKET,
+      Key: file.key,
+      UploadId: uploadId,
+      MultipartUpload: { Parts: parts }
+    })
+  );
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/app/api/upload/init/route.ts
+++ b/apps/web/app/api/upload/init/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import {
+  CreateMultipartUploadCommand,
+  UploadPartCommand
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { prisma } from "@/lib/db";
+import { s3, BUCKET } from "@/lib/s3";
+
+const PART_SIZE = 5 * 1024 * 1024;
+
+export async function POST(req: Request) {
+  const { name, type, size } = await req.json();
+  const key = `${crypto.randomUUID()}-${name}`;
+  const expiresAt = new Date(Date.now() + 70 * 60 * 1000);
+
+  const create = await s3.send(
+    new CreateMultipartUploadCommand({
+      Bucket: BUCKET,
+      Key: key,
+      ContentType: type
+    })
+  );
+
+  const uploadId = create.UploadId!;
+  const partCount = Math.ceil(size / PART_SIZE);
+
+  const parts = await Promise.all(
+    Array.from({ length: partCount }, async (_, i) => {
+      const command = new UploadPartCommand({
+        Bucket: BUCKET,
+        Key: key,
+        UploadId: uploadId,
+        PartNumber: i + 1
+      });
+      const url = await getSignedUrl(s3, command, { expiresIn: 3600 });
+      return { partNumber: i + 1, url };
+    })
+  );
+
+  const file = await prisma.file.create({
+    data: { key, name, size, expiresAt }
+  });
+
+  return NextResponse.json({
+    uploadId,
+    parts,
+    fileId: file.id,
+    key
+  });
+}

--- a/apps/web/components/Dropzone.tsx
+++ b/apps/web/components/Dropzone.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useDropzone } from "react-dropzone";
+
+interface DropzoneProps {
+  onUpload: (file: File, onProgress: (p: number) => void) => Promise<void>;
+}
+
+export function Dropzone({ onUpload }: DropzoneProps) {
+  const [progress, setProgress] = useState(0);
+
+  const handleFile = useCallback(
+    (file: File) => {
+      void onUpload(file, setProgress);
+    },
+    [onUpload]
+  );
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    multiple: false,
+    onDrop: (files) => {
+      if (files[0]) handleFile(files[0]);
+    }
+  });
+
+  const onPaste = (e: React.ClipboardEvent) => {
+    const file = e.clipboardData.files[0];
+    if (file) handleFile(file);
+  };
+
+  return (
+    <div
+      {...getRootProps()}
+      onPaste={onPaste}
+      className={`flex flex-col items-center justify-center rounded-md border-2 border-dashed p-8 text-center cursor-pointer ${
+        isDragActive ? "bg-muted" : ""
+      }`}
+    >
+      <input {...getInputProps()} />
+      <p>Drag & drop or paste files here</p>
+      {progress > 0 && (
+        <div className="mt-4 h-2 w-full rounded bg-muted">
+          <div
+            className="h-2 rounded bg-primary"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/RetentionNote.tsx
+++ b/apps/web/components/RetentionNote.tsx
@@ -1,0 +1,7 @@
+export function RetentionNote() {
+  return (
+    <p className="text-xs text-text-secondary">
+      Files are deleted automatically after about an hour.
+    </p>
+  );
+}

--- a/apps/web/components/ToolPageTemplate.tsx
+++ b/apps/web/components/ToolPageTemplate.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { Dropzone } from "./Dropzone";
+import { RetentionNote } from "./RetentionNote";
+
+interface UploadedPart {
+  ETag: string;
+  PartNumber: number;
+}
+
+export function ToolPageTemplate() {
+  const [fileId, setFileId] = useState<string | null>(null);
+
+  const upload = async (file: File, onProgress: (p: number) => void) => {
+    const initRes = await fetch("/api/upload/init", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: file.name,
+        type: file.type,
+        size: file.size
+      })
+    });
+    const initData = await initRes.json();
+    const { uploadId, parts, fileId: id } = initData;
+
+    const uploadedParts: UploadedPart[] = [];
+    const chunkSize = 5 * 1024 * 1024;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const start = i * chunkSize;
+      const end = Math.min(start + chunkSize, file.size);
+      const blob = file.slice(start, end);
+      const res = await fetch(part.url, {
+        method: "PUT",
+        body: blob
+      });
+      const etag = res.headers.get("ETag") || "";
+      uploadedParts.push({ ETag: etag, PartNumber: part.partNumber });
+      onProgress(((i + 1) / parts.length) * 100);
+    }
+
+    await fetch("/api/upload/complete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ fileId: id, uploadId, parts: uploadedParts })
+    });
+
+    setFileId(id);
+  };
+
+  if (fileId) {
+    return (
+      <div className="space-y-4">
+        <a
+          href={`/api/download/${fileId}`}
+          className="text-primary underline"
+        >
+          Download file
+        </a>
+        <RetentionNote />
+      </div>
+    );
+  }
+
+  return <Dropzone onUpload={upload} />;
+}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -1,11 +1,9 @@
-export type Plan = "FREE" | "SUPPORTER";
+import { PrismaClient } from "@prisma/client";
 
-export interface UserRecord {
-  plan: Plan;
-  usage: number;
-  stripeCustomerId?: string;
-  subscriptionStatus?: string;
-}
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
 
-// simple in-memory store for demo purposes
-export const users = new Map<string, UserRecord>();
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/apps/web/lib/s3.ts
+++ b/apps/web/lib/s3.ts
@@ -1,0 +1,12 @@
+import { S3Client } from "@aws-sdk/client-s3";
+
+export const s3 = new S3Client({
+  region: "auto",
+  endpoint: process.env.S3_ENDPOINT,
+  credentials: {
+    accessKeyId: process.env.S3_ACCESS_KEY || "",
+    secretAccessKey: process.env.S3_SECRET_KEY || ""
+  }
+});
+
+export const BUCKET = process.env.S3_BUCKET || "";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,11 @@
     "clsx": "^2.0.0",
     "tailwind-merge": "^2.0.0",
     "next-auth": "^4.24.5",
-    "stripe": "^12.17.0"
+    "stripe": "^12.17.0",
+    "@aws-sdk/client-s3": "^3.540.0",
+    "@aws-sdk/s3-request-presigner": "^3.540.0",
+    "@prisma/client": "^5.15.0",
+    "react-dropzone": "^14.2.3"
   },
   "devDependencies": {
     "typescript": "5.3.3",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -7,6 +7,11 @@
     "start": "tsx src/index.ts",
     "build": "tsc -p tsconfig.json"
   },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.540.0",
+    "@aws-sdk/s3-request-presigner": "^3.540.0",
+    "@prisma/client": "^5.15.0"
+  },
   "devDependencies": {
     "tsx": "4.7.0",
     "typescript": "5.3.3"

--- a/apps/worker/src/db.ts
+++ b/apps/worker/src/db.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from "@prisma/client";
+
+export const prisma = new PrismaClient();

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,5 +1,24 @@
+import { DeleteObjectCommand } from "@aws-sdk/client-s3";
+import { prisma } from "./db";
+import { s3, BUCKET } from "./s3";
+
+async function cleanupExpired() {
+  const expired = await prisma.file.findMany({
+    where: { expiresAt: { lt: new Date() } }
+  });
+
+  for (const file of expired) {
+    await s3.send(
+      new DeleteObjectCommand({ Bucket: BUCKET, Key: file.key })
+    );
+    await prisma.file.delete({ where: { id: file.id } });
+  }
+}
+
 export function main() {
   console.log("Worker ready");
+  void cleanupExpired();
+  setInterval(cleanupExpired, 5 * 60 * 1000);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/apps/worker/src/s3.ts
+++ b/apps/worker/src/s3.ts
@@ -1,0 +1,12 @@
+import { S3Client } from "@aws-sdk/client-s3";
+
+export const s3 = new S3Client({
+  region: "auto",
+  endpoint: process.env.S3_ENDPOINT,
+  credentials: {
+    accessKeyId: process.env.S3_ACCESS_KEY || "",
+    secretAccessKey: process.env.S3_SECRET_KEY || ""
+  }
+});
+
+export const BUCKET = process.env.S3_BUCKET || "";

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "devDependencies": {
+    "prisma": "^5.15.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,17 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model File {
+  id        String   @id @default(cuid())
+  key       String   @unique
+  name      String
+  size      Int
+  createdAt DateTime @default(now())
+  expiresAt DateTime
+}


### PR DESCRIPTION
## Summary
- add multipart upload init/complete endpoints and signed download URLs
- track uploaded files with Prisma and clean up after TTL via worker
- add dropzone with progress and retention note component

## Testing
- `pnpm install` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm build` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `DATABASE_URL="file:./dev.db" pnpm prisma generate` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dcd2eecc8333991615af977dbca5