### PR TITLE
Add Upstash rate limiting, captcha flow, and ad slot

### DIFF
--- a/apps/web/app/(site)/layout.tsx
+++ b/apps/web/app/(site)/layout.tsx
@@ -5,7 +5,7 @@ import { useState, type ReactNode } from "react";
 import { Menu } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { UpgradeStrip } from "@/components/UpgradeStrip";
+import { AdPlaceholder } from "@/components/AdPlaceholder";
 
 export default function SiteLayout({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(false);
@@ -35,8 +35,10 @@ export default function SiteLayout({ children }: { children: ReactNode }) {
           </div>
         )}
       </header>
-      <UpgradeStrip />
-      <main>{children}</main>
+      <main>
+        <AdPlaceholder />
+        {children}
+      </main>
     </div>
   );
 }

--- a/apps/web/app/(site)/tools/img-bg-remove/page.tsx
+++ b/apps/web/app/(site)/tools/img-bg-remove/page.tsx
@@ -1,9 +1,19 @@
 import { ToolWizard } from "@/components/ToolWizard";
 import { runTool } from "@/lib/runTool";
 import { z } from "zod";
+import { useSession } from "next-auth/react";
 
 const schema = z.object({});
 
 export default function Page() {
-  return <ToolWizard schema={schema} onRun={(file, values) => runTool("img-bg-remove", file, values)} />;
+  const { data: session } = useSession();
+  return (
+    <ToolWizard
+      schema={schema}
+      requireCaptcha={!session}
+      onRun={(file, values, token) =>
+        runTool("img-bg-remove", file, { ...values, captchaToken: token })
+      }
+    />
+  );
 }

--- a/apps/web/app/(site)/tools/mp4-to-mp3/page.tsx
+++ b/apps/web/app/(site)/tools/mp4-to-mp3/page.tsx
@@ -1,9 +1,19 @@
 import { ToolWizard } from "@/components/ToolWizard";
 import { runTool } from "@/lib/runTool";
 import { z } from "zod";
+import { useSession } from "next-auth/react";
 
 const schema = z.object({});
 
 export default function Page() {
-  return <ToolWizard schema={schema} onRun={(file, values) => runTool("mp4-to-mp3", file, values)} />;
+  const { data: session } = useSession();
+  return (
+    <ToolWizard
+      schema={schema}
+      requireCaptcha={!session}
+      onRun={(file, values, token) =>
+        runTool("mp4-to-mp3", file, { ...values, captchaToken: token })
+      }
+    />
+  );
 }

--- a/apps/web/app/(site)/tools/paragraph-rewriter/page.tsx
+++ b/apps/web/app/(site)/tools/paragraph-rewriter/page.tsx
@@ -1,9 +1,19 @@
 import { ToolWizard } from "@/components/ToolWizard";
 import { runTool } from "@/lib/runTool";
 import { z } from "zod";
+import { useSession } from "next-auth/react";
 
 const schema = z.object({});
 
 export default function Page() {
-  return <ToolWizard schema={schema} onRun={(file, values) => runTool("paragraph-rewriter", file, values)} />;
+  const { data: session } = useSession();
+  return (
+    <ToolWizard
+      schema={schema}
+      requireCaptcha={!session}
+      onRun={(file, values, token) =>
+        runTool("paragraph-rewriter", file, { ...values, captchaToken: token })
+      }
+    />
+  );
 }

--- a/apps/web/app/(site)/tools/video-compress/page.tsx
+++ b/apps/web/app/(site)/tools/video-compress/page.tsx
@@ -1,9 +1,19 @@
 import { ToolWizard } from "@/components/ToolWizard";
 import { runTool } from "@/lib/runTool";
 import { z } from "zod";
+import { useSession } from "next-auth/react";
 
 const schema = z.object({ bitrate: z.string().optional() });
 
 export default function Page() {
-  return <ToolWizard schema={schema} onRun={(file, values) => runTool("video-compress", file, values)} />;
+  const { data: session } = useSession();
+  return (
+    <ToolWizard
+      schema={schema}
+      requireCaptcha={!session}
+      onRun={(file, values, token) =>
+        runTool("video-compress", file, { ...values, captchaToken: token })
+      }
+    />
+  );
 }

--- a/apps/web/app/api/tools/[slug]/jobs/route.ts
+++ b/apps/web/app/api/tools/[slug]/jobs/route.ts
@@ -1,6 +1,9 @@
-import { NextResponse } from "next/server";
+import { NextResponse, NextRequest } from "next/server";
 import { Queue } from "bullmq";
 import { prisma } from "@/lib/db";
+import { auth } from "@/lib/auth";
+import { ipRateLimit, userRateLimit } from "@/lib/ratelimit";
+import { verifyCaptcha } from "@/lib/captcha";
 
 const connection = {
   host: process.env.REDIS_HOST || "localhost",
@@ -20,10 +23,30 @@ const slugToQueue: Record<string, string> = {
   "paragraph-rewriter": "ai",
 };
 
+const heavySlugs = new Set([
+  "video-compress",
+  "mp4-to-mp3",
+  "img-bg-remove",
+  "paragraph-rewriter",
+]);
+
 export async function POST(
-  req: Request,
+  req: NextRequest,
   { params }: { params: { slug: string } }
 ) {
+  const session = await auth();
+  const ip = req.ip || req.headers.get("x-forwarded-for") || "unknown";
+  const ipCheck = await ipRateLimit.limit(ip);
+  if (!ipCheck.success) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+  if (session) {
+    const userCheck = await userRateLimit.limit(session.user.id);
+    if (!userCheck.success) {
+      return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+    }
+  }
+
   const slug = params.slug;
   const queueName = slugToQueue[slug];
   if (!queueName) {
@@ -31,7 +54,14 @@ export async function POST(
   }
 
   const body = await req.json();
-  const { fileId, ...rest } = body;
+  const { fileId, captchaToken, ...rest } = body;
+
+  if (!session && heavySlugs.has(slug)) {
+    const ok = await verifyCaptcha(captchaToken);
+    if (!ok) {
+      return NextResponse.json({ error: "Captcha required" }, { status: 400 });
+    }
+  }
 
   const jobRecord = await prisma.job.create({
     data: { tool: slug, params: rest },

--- a/apps/web/components/AdPlaceholder.tsx
+++ b/apps/web/components/AdPlaceholder.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+
+export function AdPlaceholder() {
+  const { data: session } = useSession();
+  if (session && session.user.plan !== 'FREE') {
+    return null;
+  }
+  return (
+    <div className="my-6 flex justify-center">
+      <div className="h-32 w-full max-w-5xl bg-zinc-200 text-sm text-zinc-600 flex items-center justify-center">
+        Ad Placeholder
+      </div>
+    </div>
+  );
+}
+

--- a/apps/web/components/Captcha.tsx
+++ b/apps/web/components/Captcha.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import Turnstile from 'react-turnstile';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
+
+export function Captcha({ onVerify }: { onVerify: (token: string) => void }) {
+  const turnstileKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+  const hcaptchaKey = process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY;
+
+  if (turnstileKey) {
+    return <Turnstile sitekey={turnstileKey} onVerify={onVerify} />;
+  }
+  if (hcaptchaKey) {
+    return <HCaptcha sitekey={hcaptchaKey} onVerify={(token) => onVerify(token)} />;
+  }
+  return null;
+}
+

--- a/apps/web/components/UpgradeStrip.tsx
+++ b/apps/web/components/UpgradeStrip.tsx
@@ -1,7 +1,7 @@
 export function UpgradeStrip() {
   return (
     <div className="bg-primary py-2 text-center text-sm text-white">
-      Ad-free, no captcha, faster processing
+      ad-free / no captcha / faster
     </div>
   );
 }

--- a/apps/web/lib/captcha.ts
+++ b/apps/web/lib/captcha.ts
@@ -1,0 +1,13 @@
+export async function verifyCaptcha(token: string | undefined) {
+  if (!token) return false;
+  const secret = process.env.TURNSTILE_SECRET_KEY || process.env.HCAPTCHA_SECRET_KEY;
+  if (!secret) return false;
+  const body = new URLSearchParams({ secret, response: token });
+  const url = process.env.TURNSTILE_SECRET_KEY
+    ? 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
+    : 'https://hcaptcha.com/siteverify';
+  const res = await fetch(url, { method: 'POST', body });
+  const data = await res.json();
+  return !!data.success;
+}
+

--- a/apps/web/lib/ratelimit.ts
+++ b/apps/web/lib/ratelimit.ts
@@ -1,0 +1,15 @@
+import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
+
+const redis = Redis.fromEnv();
+
+export const ipRateLimit = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(100, '1 h'),
+});
+
+export const userRateLimit = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(100, '1 h'),
+});
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,8 +24,11 @@
     "zod": "^3.23.8",
     "@aws-sdk/client-s3": "^3.540.0",
     "@aws-sdk/s3-request-presigner": "^3.540.0",
-    "@prisma/client": "^5.15.0",
-    "react-dropzone": "^14.2.3"
+    "react-dropzone": "^14.2.3",
+    "@upstash/ratelimit": "^1.0.0",
+    "@upstash/redis": "^1.0.0",
+    "react-turnstile": "^1.0.0",
+    "@hcaptcha/react-hcaptcha": "^1.9.3"
   },
   "devDependencies": {
     "typescript": "5.3.3",


### PR DESCRIPTION
## Summary
- add IP and user rate limiting with Upstash
- require Turnstile/hCaptcha for anonymous heavy jobs
- add single-page AdPlaceholder and update upgrade messaging

## Testing
- `pnpm install` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm build` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e3889ab083338b47bc2c4e702700