### PR TITLE
feat: improve tool UX with breadcrumbs and toasts

### DIFF
--- a/apps/web/app/(site)/layout.tsx
+++ b/apps/web/app/(site)/layout.tsx
@@ -6,6 +6,7 @@ import { Menu } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { AdPlaceholder } from "@/components/AdPlaceholder";
+import { Footer } from "@/components/Footer";
 
 export default function SiteLayout({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(false);
@@ -39,6 +40,7 @@ export default function SiteLayout({ children }: { children: ReactNode }) {
         <AdPlaceholder />
         {children}
       </main>
+      <Footer />
     </div>
   );
 }

--- a/apps/web/app/(site)/tools/img-bg-remove/page.tsx
+++ b/apps/web/app/(site)/tools/img-bg-remove/page.tsx
@@ -1,5 +1,6 @@
-import { ToolWizard } from "@/components/ToolWizard";
-import { runTool } from "@/lib/runTool";
+"use client";
+
+import { ToolPage } from "@/components/ToolPage";
 import { z } from "zod";
 import { useSession } from "next-auth/react";
 
@@ -7,13 +8,5 @@ const schema = z.object({});
 
 export default function Page() {
   const { data: session } = useSession();
-  return (
-    <ToolWizard
-      schema={schema}
-      requireCaptcha={!session}
-      onRun={(file, values, token) =>
-        runTool("img-bg-remove", file, { ...values, captchaToken: token })
-      }
-    />
-  );
+  return <ToolPage toolId="img-bg-remove" schema={schema} requireCaptcha={!session} />;
 }

--- a/apps/web/app/(site)/tools/img-compress/page.tsx
+++ b/apps/web/app/(site)/tools/img-compress/page.tsx
@@ -1,9 +1,8 @@
-import { ToolWizard } from "@/components/ToolWizard";
-import { runTool } from "@/lib/runTool";
+import { ToolPage } from "@/components/ToolPage";
 import { z } from "zod";
 
 const schema = z.object({ quality: z.string().optional() });
 
 export default function Page() {
-  return <ToolWizard schema={schema} onRun={(file, values) => runTool("img-compress", file, values)} />;
+  return <ToolPage toolId="img-compress" schema={schema} />;
 }

--- a/apps/web/app/(site)/tools/img-resize/page.tsx
+++ b/apps/web/app/(site)/tools/img-resize/page.tsx
@@ -1,9 +1,8 @@
-import { ToolWizard } from "@/components/ToolWizard";
-import { runTool } from "@/lib/runTool";
+import { ToolPage } from "@/components/ToolPage";
 import { z } from "zod";
 
 const schema = z.object({ width: z.string().optional(), height: z.string().optional() });
 
 export default function Page() {
-  return <ToolWizard schema={schema} onRun={(file, values) => runTool("img-resize", file, values)} />;
+  return <ToolPage toolId="img-resize" schema={schema} />;
 }

--- a/apps/web/app/(site)/tools/mp4-to-mp3/page.tsx
+++ b/apps/web/app/(site)/tools/mp4-to-mp3/page.tsx
@@ -1,5 +1,6 @@
-import { ToolWizard } from "@/components/ToolWizard";
-import { runTool } from "@/lib/runTool";
+"use client";
+
+import { ToolPage } from "@/components/ToolPage";
 import { z } from "zod";
 import { useSession } from "next-auth/react";
 
@@ -7,13 +8,5 @@ const schema = z.object({});
 
 export default function Page() {
   const { data: session } = useSession();
-  return (
-    <ToolWizard
-      schema={schema}
-      requireCaptcha={!session}
-      onRun={(file, values, token) =>
-        runTool("mp4-to-mp3", file, { ...values, captchaToken: token })
-      }
-    />
-  );
+  return <ToolPage toolId="mp4-to-mp3" schema={schema} requireCaptcha={!session} />;
 }

--- a/apps/web/app/(site)/tools/paragraph-rewriter/page.tsx
+++ b/apps/web/app/(site)/tools/paragraph-rewriter/page.tsx
@@ -1,5 +1,6 @@
-import { ToolWizard } from "@/components/ToolWizard";
-import { runTool } from "@/lib/runTool";
+"use client";
+
+import { ToolPage } from "@/components/ToolPage";
 import { z } from "zod";
 import { useSession } from "next-auth/react";
 
@@ -7,13 +8,5 @@ const schema = z.object({});
 
 export default function Page() {
   const { data: session } = useSession();
-  return (
-    <ToolWizard
-      schema={schema}
-      requireCaptcha={!session}
-      onRun={(file, values, token) =>
-        runTool("paragraph-rewriter", file, { ...values, captchaToken: token })
-      }
-    />
-  );
+  return <ToolPage toolId="paragraph-rewriter" schema={schema} requireCaptcha={!session} />;
 }

--- a/apps/web/app/(site)/tools/pdf-compress/page.tsx
+++ b/apps/web/app/(site)/tools/pdf-compress/page.tsx
@@ -1,9 +1,8 @@
-import { ToolWizard } from "@/components/ToolWizard";
-import { runTool } from "@/lib/runTool";
+import { ToolPage } from "@/components/ToolPage";
 import { z } from "zod";
 
 const schema = z.object({ level: z.string().optional() });
 
 export default function Page() {
-  return <ToolWizard schema={schema} onRun={(file, values) => runTool("pdf-compress", file, values)} />;
+  return <ToolPage toolId="pdf-compress" schema={schema} />;
 }

--- a/apps/web/app/(site)/tools/pdf-merge/page.tsx
+++ b/apps/web/app/(site)/tools/pdf-merge/page.tsx
@@ -1,9 +1,8 @@
-import { ToolWizard } from "@/components/ToolWizard";
-import { runTool } from "@/lib/runTool";
+import { ToolPage } from "@/components/ToolPage";
 import { z } from "zod";
 
 const schema = z.object({});
 
 export default function Page() {
-  return <ToolWizard schema={schema} onRun={(file, values) => runTool("pdf-merge", file, values)} />;
+  return <ToolPage toolId="pdf-merge" schema={schema} />;
 }

--- a/apps/web/app/(site)/tools/pdf-split/page.tsx
+++ b/apps/web/app/(site)/tools/pdf-split/page.tsx
@@ -1,9 +1,8 @@
-import { ToolWizard } from "@/components/ToolWizard";
-import { runTool } from "@/lib/runTool";
+import { ToolPage } from "@/components/ToolPage";
 import { z } from "zod";
 
 const schema = z.object({ pages: z.string().optional() });
 
 export default function Page() {
-  return <ToolWizard schema={schema} onRun={(file, values) => runTool("pdf-split", file, values)} />;
+  return <ToolPage toolId="pdf-split" schema={schema} />;
 }

--- a/apps/web/app/(site)/tools/pdf-to-jpg/page.tsx
+++ b/apps/web/app/(site)/tools/pdf-to-jpg/page.tsx
@@ -1,9 +1,8 @@
-import { ToolWizard } from "@/components/ToolWizard";
-import { runTool } from "@/lib/runTool";
+import { ToolPage } from "@/components/ToolPage";
 import { z } from "zod";
 
 const schema = z.object({});
 
 export default function Page() {
-  return <ToolWizard schema={schema} onRun={(file, values) => runTool("pdf-to-jpg", file, values)} />;
+  return <ToolPage toolId="pdf-to-jpg" schema={schema} />;
 }

--- a/apps/web/app/(site)/tools/video-compress/page.tsx
+++ b/apps/web/app/(site)/tools/video-compress/page.tsx
@@ -1,5 +1,6 @@
-import { ToolWizard } from "@/components/ToolWizard";
-import { runTool } from "@/lib/runTool";
+"use client";
+
+import { ToolPage } from "@/components/ToolPage";
 import { z } from "zod";
 import { useSession } from "next-auth/react";
 
@@ -7,13 +8,5 @@ const schema = z.object({ bitrate: z.string().optional() });
 
 export default function Page() {
   const { data: session } = useSession();
-  return (
-    <ToolWizard
-      schema={schema}
-      requireCaptcha={!session}
-      onRun={(file, values, token) =>
-        runTool("video-compress", file, { ...values, captchaToken: token })
-      }
-    />
-  );
+  return <ToolPage toolId="video-compress" schema={schema} requireCaptcha={!session} />;
 }

--- a/apps/web/app/(site)/your-data/page.tsx
+++ b/apps/web/app/(site)/your-data/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-10 space-y-4">
+      <h1 className="text-2xl font-bold">Your Data</h1>
+      <p>Learn how we handle your files and information.</p>
+    </div>
+  );
+}

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -3,7 +3,12 @@
 import { SessionProvider } from "next-auth/react";
 import type { ReactNode } from "react";
 import type { Session } from "next-auth";
+import { ToastProvider } from "@/components/ToastProvider";
 
 export function Providers({ children, session }: { children: ReactNode; session: Session | null }) {
-  return <SessionProvider session={session}>{children}</SessionProvider>;
+  return (
+    <SessionProvider session={session}>
+      <ToastProvider>{children}</ToastProvider>
+    </SessionProvider>
+  );
 }

--- a/apps/web/components/Breadcrumbs.tsx
+++ b/apps/web/components/Breadcrumbs.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import Link from "next/link";
+
+interface Crumb {
+  href: string;
+  label: string;
+}
+
+export function Breadcrumbs({ items }: { items: Crumb[] }) {
+  return (
+    <nav className="text-sm text-text-secondary" aria-label="Breadcrumb">
+      {items.map((item, i) => (
+        <span key={item.href}>
+          <Link href={item.href} className="hover:underline text-primary">
+            {item.label}
+          </Link>
+          {i < items.length - 1 && <span className="mx-1">→</span>}
+        </span>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/components/Dropzone.tsx
+++ b/apps/web/components/Dropzone.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { useDropzone } from "react-dropzone";
+import { useToast } from "./ToastProvider";
 
 interface DropzoneProps {
   onUpload: (file: File, onProgress: (p: number) => void) => Promise<void>;
@@ -9,12 +10,19 @@ interface DropzoneProps {
 
 export function Dropzone({ onUpload }: DropzoneProps) {
   const [progress, setProgress] = useState(0);
+  const toast = useToast();
 
   const handleFile = useCallback(
-    (file: File) => {
-      void onUpload(file, setProgress);
+    async (file: File) => {
+      toast("Upload started");
+      try {
+        await onUpload(file, setProgress);
+        toast("Upload complete", "success");
+      } catch {
+        toast("Upload error", "error");
+      }
     },
-    [onUpload]
+    [onUpload, toast]
   );
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
@@ -34,7 +42,7 @@ export function Dropzone({ onUpload }: DropzoneProps) {
       {...getRootProps()}
       onPaste={onPaste}
       className={`flex flex-col items-center justify-center rounded-md border-2 border-dashed p-8 text-center cursor-pointer ${
-        isDragActive ? "bg-muted" : ""
+        isDragActive ? "bg-muted border-primary" : ""
       }`}
     >
       <input {...getInputProps()} />

--- a/apps/web/components/Footer.tsx
+++ b/apps/web/components/Footer.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Link from "next/link";
+import { RetentionNote } from "./RetentionNote";
+
+export function Footer() {
+  return (
+    <footer className="border-t border-border bg-surface mt-10">
+      <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-4 py-6 text-sm text-text-secondary md:flex-row">
+        <div className="flex gap-4">
+          <Link href="/tools" className="hover:underline">
+            Tools
+          </Link>
+          <Link href="/support" className="hover:underline">
+            Support
+          </Link>
+          <Link href="/privacy" className="hover:underline">
+            Privacy
+          </Link>
+          <Link href="/your-data" className="hover:underline">
+            Your Data
+          </Link>
+        </div>
+        <RetentionNote />
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/components/ToastProvider.tsx
+++ b/apps/web/components/ToastProvider.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+
+interface Toast {
+  id: number;
+  message: string;
+  type?: "success" | "error";
+}
+
+const ToastContext = createContext<(msg: string, type?: "success" | "error") => void>(() => {});
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const addToast = (message: string, type?: "success" | "error") => {
+    const id = Date.now();
+    setToasts((t) => [...t, { id, message, type }]);
+    setTimeout(() => {
+      setToasts((t) => t.filter((toast) => toast.id !== id));
+    }, 3000);
+  };
+
+  return (
+    <ToastContext.Provider value={addToast}>
+      {children}
+      <div className="fixed top-4 right-4 space-y-2 z-50">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={`rounded px-4 py-2 text-white ${
+              t.type === "error" ? "bg-red-500" : "bg-gray-800"
+            }`}
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  return useContext(ToastContext);
+}

--- a/apps/web/components/ToolCard.tsx
+++ b/apps/web/components/ToolCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import { type LucideIcon } from "lucide-react";
 import { PremiumBadge } from "./PremiumBadge";
@@ -14,6 +16,7 @@ export function ToolCard({ id, icon: Icon, title, description, premium }: ToolCa
   return (
     <Link
       href={`/tools/${id}`}
+      prefetch={false}
       className="block rounded-lg border border-border bg-surface p-4 shadow-sm transition-shadow hover:shadow-md"
     >
       <div className="mb-2 flex items-center">

--- a/apps/web/components/ToolPage.tsx
+++ b/apps/web/components/ToolPage.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { z, ZodObject } from "zod";
+import { ToolWizard } from "./ToolWizard";
+import { tools, categorySlugs } from "@/constants/tools";
+import { Breadcrumbs } from "./Breadcrumbs";
+import { runTool } from "@/lib/runTool";
+
+interface ToolPageProps<T extends ZodObject<any>> {
+  toolId: string;
+  schema: T;
+  requireCaptcha?: boolean;
+}
+
+export function ToolPage<T extends ZodObject<any>>({ toolId, schema, requireCaptcha }: ToolPageProps<T>) {
+  const tool = tools.find((t) => t.id === toolId)!;
+  return (
+    <div className="space-y-6">
+      <Breadcrumbs
+        items={[
+          { href: "/", label: "Home" },
+          {
+            href: `/tools/${categorySlugs[tool.category]}`,
+            label: `${tool.category} Tools`,
+          },
+          { href: `/tools/${tool.id}`, label: tool.title },
+        ]}
+      />
+      <ToolWizard
+        toolId={toolId}
+        schema={schema}
+        requireCaptcha={requireCaptcha}
+        onRun={(file, values, token) =>
+          runTool(toolId, file, { ...values, captchaToken: token })
+        }
+      />
+    </div>
+  );
+}

--- a/apps/web/constants/tools.ts
+++ b/apps/web/constants/tools.ts
@@ -17,6 +17,14 @@ export interface Tool {
   premium?: boolean;
 }
 
+export const categorySlugs: Record<CategoryName, string> = {
+  PDF: "pdf",
+  Image: "image",
+  Video: "video",
+  "File Conversion": "file_conversion",
+  "AI Write": "write",
+};
+
 export const tools: Tool[] = [
   {
     id: "pdf-merge",


### PR DESCRIPTION
## Summary
- add breadcrumb navigation and shared ToolPage wrapper for tool routes
- introduce toast notifications, run-again flow, and related tool suggestions
- add footer with retention note and disable link prefetch for large tool lists

## Testing
- `pnpm -F web build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f0684a1083339ce0270bd9fa1112