### PR TITLE
fix: handle nullable NextAuth user id

### DIFF
--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -17,7 +17,9 @@ export const { handlers: { GET, POST }, auth, signIn, signOut } = NextAuth({
   ],
   callbacks: {
     async jwt({ token, user }) {
-      if (user) token.sub = user.id || user.email;
+      if (user) {
+        token.sub = user.id ?? user.email ?? undefined;
+      }
       return token;
     },
     async session({ session, token }) {

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -7,3 +7,13 @@ export const prisma =
   new PrismaClient();
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+
+export type Plan = "FREE" | "PRO";
+
+export interface UserRecord {
+  plan: Plan;
+  usage: number;
+  stripeCustomerId?: string;
+}
+
+export const users = new Map<string, UserRecord>();


### PR DESCRIPTION
## Summary
- avoid assigning null to token.sub when deriving NextAuth JWT subject
- add typed in-memory user store and plan enum

## Testing
- `./node_modules/.bin/next build` *(fails: Module not found: Can't resolve 'zod')*

------
https://chatgpt.com/codex/tasks/task_e_68b537c2a07483339a5965dafafc2bf4